### PR TITLE
Provide an example systemd service file

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,3 @@
+Systemd files for Wireproxy
+
+`ff`

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,3 +1,47 @@
-Systemd files for Wireproxy
+# Running wireproxy with systemd
 
-`ff`
+If you're on a systemd-based distro, you'll most likely want to run Wireproxy as a systemd unit.
+
+The provided systemd unit assumes you have the wireproxy executable installed on `/opt/wireproxy/wireproxy` and a configuration file stored at `/etc/wireproxy.conf`. These paths can be customized by editing the unit file.
+
+# Setting up the unit
+
+1. Copy the `wireproxy.service` file from this directory to `/etc/systemd/system/`, or use the following cURL command to download it:
+   ```bash
+   sudo curl https://raw.githubusercontent.com/pufferffish/wireproxy/master/systemd/wireproxy.service > /etc/systemd/system/wireproxy.service
+   ```
+
+2. If necessary, customize the unit.
+
+   Edit the parts with `ExecStartPre=` and `ExecStart=` to point to the executable and the configuration file. For example, if wireproxy is installed on `/usr/bin` and the configuration file is located in `/opt/myfiles/wireproxy.conf` do the following change:
+   ```service
+   ExecStartPre=/usr/bin/wireproxy -n -c /opt/myfiles/wireproxy.conf
+   ExecStart=/usr/bin/wireproxy -c /opt/myfiles/wireproxy.conf
+   ```
+   #### 2.2 Drop root privileges (optional, but recommended)
+   Without any modifications, this Wireproxy service will run as root. You might want to drop those privileges. One way to do this is to simply create a system account for Wireproxy (or just use your own user account to run it instead).
+   ```bash
+   sudo useradd --comment "Wireproxy tunnel" --system wireproxy
+   ```
+   Then uncomment these lines from the wireproxy.service:
+   ```service
+   #User=wireproxy
+   #Group=wireproxy
+   ```
+   Caveats:
+     1) Make sure `wireproxy` user can read the wireproxy configuration file.
+     2) Also note that unprivileged user cannot bind to ports below 1024 by default.
+
+4. Reload systemd and enable the unit.
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now wireproxy.service
+   ```
+
+5. Make sure it's working correctly.
+
+   Finally, check out the unit status to confirm `wireproxy.service` has started without problems. You can use commands like `systemctl status wireproxy.service` and/or `sudo journalctl -u wireproxy.service`.
+
+# Additional notes
+
+If you want to disable the extensive logging that's done by Wireproxy, simply add `-s` parameter to `ExecStart=`. This will enable the silent mode that was implemented with [pull/67](https://github.com/pufferffish/wireproxy/pull/67).

--- a/systemd/wireproxy.service
+++ b/systemd/wireproxy.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Wireproxy socks5/http tunnel
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+#Uncomment and/or change these if you don't want to run Wireproxy as root
+#User=wireproxy
+#Group=wireproxy
+Type=simple
+Restart=on-failure
+RestartSec=30s
+ExecStartPre=/opt/wireproxy/wireproxy -n -c /etc/wireproxy.conf
+ExecStart=/opt/wireproxy/wireproxy -c /etc/wireproxy.conf
+SyslogIdentifier=wireproxy
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I checked out the Wireproxy Github issue list and there's been some talk about running Wireproxy with systemd but there's no example unit file provided. I provided the one I created and it's been working fine so far. I also included a README for some instructions.

I've been using Linux for around 20 years but I haven't had a systemd distro until a few months ago, so I'm fairly inexperienced with unit files. There's probably stuff that could be improved but this should be a good starting starting point.