### PR TITLE
Support env lookup for some values

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -59,6 +59,7 @@ jobs:
           docker buildx build \
             --platform "$BUILD_PLATFORMS" \
             --tag "$CONTAINER_NAME:$CONTAINER_TAG" \
+            --tag "$CONTAINER_NAME:$GITHUB_SHA" \
             --label "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
             --label "org.opencontainers.image.documentation=${{ github.server_url }}/${{ github.repository }}" \
             --label "org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}/packages" \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Instructions for using wireproxy with Firefox container tabs and auto-start on M
 Address = 10.200.200.2/32 # The subnet should be /32 and /128 for IPv4 and v6 respectively
 # MTU = 1420 (optional)
 PrivateKey = uCTIK+56CPyCvwJxmU5dBfuyJvPuSXAq1FzHdnIxe1Q=
+# PrivateKey = $MY_WIREGUARD_PRIVATE_KEY # Alternatively, reference environment variables
 DNS = 10.200.200.1
 
 [Peer]

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/go-ini/ini"
@@ -68,6 +69,18 @@ func parseString(section *ini.Section, keyName string) (string, error) {
 	if key == nil {
 		return "", errors.New(keyName + " should not be empty")
 	}
+	value := key.String()
+	if strings.HasPrefix(value, "$") {
+		if strings.HasPrefix(value, "$$") {
+			return strings.Replace(value, "$$", "$", 1), nil
+		}
+		var ok bool
+		value, ok = os.LookupEnv(strings.TrimPrefix(value, "$"))
+		if !ok {
+			return "", errors.New(keyName + " references unset environment variable " + key.String())
+		}
+		return value, nil
+	}
 	return key.String(), nil
 }
 
@@ -122,15 +135,21 @@ func encodeBase64ToHex(key string) (string, error) {
 }
 
 func parseNetIP(section *ini.Section, keyName string) ([]netip.Addr, error) {
-	key := section.Key(keyName)
-	if key == nil {
-		return []netip.Addr{}, nil
+	key, err := parseString(section, keyName)
+	if err != nil {
+		if strings.Contains(err.Error(), "should not be empty") {
+			return []netip.Addr{}, nil
+		}
+		return nil, err
 	}
 
-	keys := key.StringsWithShadows(",")
+	keys := strings.Split(key, ",")
 	var ips = make([]netip.Addr, 0, len(keys))
 	for _, str := range keys {
 		str = strings.TrimSpace(str)
+		if len(str) == 0 {
+			continue
+		}
 		ip, err := netip.ParseAddr(str)
 		if err != nil {
 			return nil, err
@@ -141,14 +160,21 @@ func parseNetIP(section *ini.Section, keyName string) ([]netip.Addr, error) {
 }
 
 func parseCIDRNetIP(section *ini.Section, keyName string) ([]netip.Addr, error) {
-	key := section.Key(keyName)
-	if key == nil {
-		return []netip.Addr{}, nil
+	key, err := parseString(section, keyName)
+	if err != nil {
+		if strings.Contains(err.Error(), "should not be empty") {
+			return []netip.Addr{}, nil
+		}
+		return nil, err
 	}
 
-	keys := key.StringsWithShadows(",")
+	keys := strings.Split(key, ",")
 	var ips = make([]netip.Addr, 0, len(keys))
 	for _, str := range keys {
+		str = strings.TrimSpace(str)
+		if len(str) == 0 {
+			continue
+		}
 		prefix, err := netip.ParsePrefix(str)
 		if err != nil {
 			return nil, err
@@ -161,14 +187,21 @@ func parseCIDRNetIP(section *ini.Section, keyName string) ([]netip.Addr, error) 
 }
 
 func parseAllowedIPs(section *ini.Section) ([]netip.Prefix, error) {
-	key := section.Key("AllowedIPs")
-	if key == nil {
-		return []netip.Prefix{}, nil
+	key, err := parseString(section, "AllowedIPs")
+	if err != nil {
+		if strings.Contains(err.Error(), "should not be empty") {
+			return []netip.Prefix{}, nil
+		}
+		return nil, err
 	}
 
-	keys := key.StringsWithShadows(",")
+	keys := strings.Split(key, ",")
 	var ips = make([]netip.Prefix, 0, len(keys))
 	for _, str := range keys {
+		str = strings.TrimSpace(str)
+		if len(str) == 0 {
+			continue
+		}
 		prefix, err := netip.ParsePrefix(str)
 		if err != nil {
 			return nil, err
@@ -288,8 +321,7 @@ func ParsePeers(cfg *ini.File, peers *[]PeerConfig) error {
 			peer.PreSharedKey = value
 		}
 
-		if sectionKey, err := section.GetKey("Endpoint"); err == nil {
-			value := sectionKey.String()
+		if value, err := parseString(section, "Endpoint"); err == nil {
 			decoded, err = resolveIPPAndPort(strings.ToLower(value))
 			if err != nil {
 				return err


### PR DESCRIPTION
Support referencing environment variables in Wireproxy config. This simplifies usingusing Wireproxy in docker-compose setups where several wireproxy containers are used to impersonate and proxy to services running elsewhere - a common config file can be used with `ENDPOINT` substituted for an environment variable.

I've only addressed the configuration values that were required for my setup, along with any that were relatively east to do. 

I've also updated GH actions container build to include a commit sha as a tag to allow better pinning of image version.