### PR TITLE
Fix broken sandboxing resulting in SIGABRT

### DIFF
--- a/systemd/wireproxy.service
+++ b/systemd/wireproxy.service
@@ -40,7 +40,7 @@ RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK
 RestrictNamespaces=true
 RestrictRealtime=true
 SystemCallArchitectures=native
-SystemCallFilter=@system-service
+SystemCallFilter=@system-service @sandbox
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Something in wireproxy calls `landlock_create_ruleset`, which triggers systemd killing the unit as that's not in the allowed syscall list. Easiest fix here is allowing it to call said fn.