### PR TITLE
Fix PingRecord race condition

### DIFF
--- a/routine.go
+++ b/routine.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sourcegraph/conc"
@@ -48,7 +49,8 @@ type VirtualTun struct {
 	SystemDNS bool
 	Conf      *DeviceConfig
 	// PingRecord stores the last time an IP was pinged
-	PingRecord map[string]uint64
+	PingRecord     map[string]uint64
+	PingRecordLock *sync.Mutex
 }
 
 // RoutineSpawner spawns a routine (e.g. socks5, tcp static routes) after the configuration is parsed
@@ -475,7 +477,9 @@ func (d VirtualTun) pingIPs() {
 				}
 			}
 
+			d.PingRecordLock.Lock()
 			d.PingRecord[addr.String()] = uint64(time.Now().Unix())
+			d.PingRecordLock.Unlock()
 
 			defer socket.Close()
 		}()

--- a/wireguard.go
+++ b/wireguard.go
@@ -3,6 +3,7 @@ package wireproxy
 import (
 	"bytes"
 	"fmt"
+	"sync"
 
 	"net/netip"
 
@@ -81,10 +82,11 @@ func StartWireguard(conf *DeviceConfig, logLevel int) (*VirtualTun, error) {
 	}
 
 	return &VirtualTun{
-		Tnet:       tnet,
-		Dev:        dev,
-		Conf:       conf,
-		SystemDNS:  len(setting.DNS) == 0,
-		PingRecord: make(map[string]uint64),
+		Tnet:           tnet,
+		Dev:            dev,
+		Conf:           conf,
+		SystemDNS:      len(setting.DNS) == 0,
+		PingRecord:     make(map[string]uint64),
+		PingRecordLock: new(sync.Mutex),
 	}, nil
 }


### PR DESCRIPTION
A race condition occurs on PingRecord writes.
This occurs with high probability when multiple CheckAlives are set.

Resolve: #126, #132 