### PR TITLE
Make sure that closing one direction closes the other, too.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/akamensky/argparse v1.4.0
 	github.com/go-ini/ini v1.67.0
 	github.com/landlock-lsm/go-landlock v0.0.0-20240216195629-efb66220540a
-	github.com/sourcegraph/conc v0.3.0
 	github.com/things-go/go-socks5 v0.0.5
 	golang.org/x/net v0.23.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/landlock-lsm/go-landlock v0.0.0-20240216195629-efb66220540a h1:dz+a1M
 github.com/landlock-lsm/go-landlock v0.0.0-20240216195629-efb66220540a/go.mod h1:1NY/VPO8xm3hXw3f+M65z+PJDLUaZA5cu7OfanxoUzY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
-github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/things-go/go-socks5 v0.0.5 h1:qvKaGcBkfDrUL33SchHN93srAmYGzb4CxSM2DPYufe8=

--- a/http.go
+++ b/http.go
@@ -30,7 +30,7 @@ func (s *HTTPServer) authenticate(req *http.Request) (int, error) {
 
 	auth := req.Header.Get(proxyAuthHeaderKey)
 	if auth == "" {
-		return http.StatusProxyAuthRequired, fmt.Errorf(http.StatusText(http.StatusProxyAuthRequired))
+		return http.StatusProxyAuthRequired, fmt.Errorf("%s", http.StatusText(http.StatusProxyAuthRequired))
 	}
 
 	enc := strings.TrimPrefix(auth, "Basic ")
@@ -134,14 +134,14 @@ func (s *HTTPServer) serve(conn net.Conn) {
 		defer conn.Close()
 		defer peer.Close()
 
-		io.Copy(conn, peer)
+		_, _ = io.Copy(conn, peer)
 	}()
 
 	go func() {
 		defer conn.Close()
 		defer peer.Close()
 
-		io.Copy(peer, conn)
+		_, _ = io.Copy(peer, conn)
 	}()
 }
 

--- a/http.go
+++ b/http.go
@@ -10,8 +10,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-
-	"github.com/sourcegraph/conc"
 )
 
 const proxyAuthHeaderKey = "Proxy-Authorization"
@@ -131,17 +129,19 @@ func (s *HTTPServer) serve(conn net.Conn) {
 		log.Println("dial proxy failed: peer nil")
 		return
 	}
+
 	go func() {
-		wg := conc.NewWaitGroup()
-		wg.Go(func() {
-			_, err = io.Copy(conn, peer)
-			_ = conn.Close()
-		})
-		wg.Go(func() {
-			_, err = io.Copy(peer, conn)
-			_ = peer.Close()
-		})
-		wg.Wait()
+		defer conn.Close()
+		defer peer.Close()
+
+		io.Copy(conn, peer)
+	}()
+
+	go func() {
+		defer conn.Close()
+		defer peer.Close()
+
+		io.Copy(peer, conn)
 	}()
 }
 


### PR DESCRIPTION
This PR closes issue #130 . The regression was introduced in commit a2d7aec / PR #100 . As I cannot see any memory issues with the code replaced by #100 I just restored the old behaviour of closing both connections as soon as one of them terminates.

The issue of handling half-open connections mentioned by @leahneukirchen in said issue remains. Ideally, a FIN on connection A should only trigger a `closeWrite` connection B, and the proxy should keep relaying data from B to A until B is closed by the remote. However, this was not handled before #100 was merged either 😏 